### PR TITLE
Add meta viewport to disable device scaling

### DIFF
--- a/html5tagger/document.py
+++ b/html5tagger/document.py
@@ -2,7 +2,7 @@ from .builder import Builder
 from .util import HTML
 
 
-def Document(*title, _urls=None, **html_attrs) -> Builder:
+def Document(*title, _urls=None, _viewport=None, **html_attrs) -> Builder:
     """Construct a new document with a DOCTYPE and minimal structure.
 
     The html tag is added if any attributes are provided for it.
@@ -11,13 +11,20 @@ def Document(*title, _urls=None, **html_attrs) -> Builder:
     E.g. Document("Page title", lang="en") produces a valid document, whereas
     Document() produces only a DOCTYPE declaration.
 
-    Stylesheets, scripts and favicon passed in _urls will be linked in."""
+    Stylesheets, scripts and favicon passed in _urls will be linked in.
+    
+    Meta viewport may be added to disable device scaling (True) or using a
+    custom string value for any other setting."""
     doc = Builder("Document Builder")(HTML("<!DOCTYPE html>"))
     if html_attrs:
         doc.html(**html_attrs)
     if title:
         doc.meta(charset="utf-8")  # Always a good idea
         doc.title(*title)
+    if _viewport is not None:
+        if _viewport is True:
+            _viewport = "width=device-width,initial-scale=1"
+        doc.meta(name="viewport", content=_viewport)
     for url in _urls or ():
         fn = url.rsplit("/", 1)[-1]
         ext = fn.rsplit(".", 1)[-1]


### PR DESCRIPTION
A shorthand to disable device scaling, or to use some other option on it if customization is needed. Notably nearly all advanced sites appear to be using the setting that is obtained by `Document(_viewport=True)`. We do not still make that the default, as using the option means having to write CSS for responsive web design.