### PR TITLE
Make doc.script and doc.style work as expected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,13 +102,13 @@ with doc.ul:  # Nest using with
     doc.ul(E.li("Easy").li("Peasy"))  # Nest using (...)
 ```
 
-## Escaping
+## Escaping and special methods
 
-All content and attributes are automatically escaped. For instance, we can put the entire document into an iframe's srcdoc attribute where only the minimal but necessary escaping is applied. Use custom methods `_script`, `_style` and `_comment` for corresponding inline formats, to follow their custom escaping rules.
+All content and attributes are automatically escaped with rules depending on context where it appears. For instance, we can put the entire document into an iframe's srcdoc attribute where only the minimal but necessary escaping is applied. Methods `script`, `style` and `_comment` follow their custom escaping rules. Note that parenthesis must be added after these with optional attributes and str content: the element will immediately close without needing explicit `None` content for an empty element.
 
 ```python
 doc = Document("Escaping & Context")
-doc._style('h1::after {content: "</Style>"}').h1("<Escape>")
+doc.style('h1::after {content: "</Style>"}').h1("<Escape>")
 doc._comment("All-->OK")
 doc.iframe(srcdoc=Document().p("&amp; is used for &"))
 ```
@@ -157,14 +157,11 @@ Jinja2 renders similar document from memory template within about 10 µs but it 
 
 In the above benchmark html5tagger created the entire document from scratch, one element and attribute at a time. Unless you are creating very large documents dynamically, this should be quite fast enough.
 
-
 ## Further development
 
 There have been no changes to the tagging API since 2018 when this module was brought to production use, and thus the interface is considered stable.
 
 In 2023 support for templating was added, allowing documents to be preformatted for all their static parts (as long strings), with only templates filled in between. This is a work on progress and has not been optimized yet.
-
-Additionally, `_script` and `_style` special methods were added in 2023. These may eventually replace also the non-underscored automatic versions but for now a separate method was easier to implement.
 
 Pull requests are still welcome.
 

--- a/html5tagger/builder.py
+++ b/html5tagger/builder.py
@@ -169,16 +169,20 @@ class Builder:
         self._pieces.append(f"<!--{text}-->")
         return self
 
-    def _script(self, code: str, **attrs):
+    def script(self, code: str | None = None, **attrs):
         """Add inline JavaScript correctly escaped."""
         self._endtag_close()
-        code = escape_special(esc_script, code)
+        code = escape_special(esc_script, code) if code else ""
         self._pieces.append(f"<script{attributes(attrs)}>{code}</script>")
         return self
 
-    def _style(self, code: str, **attrs):
+    def style(self, code: str | None = None, **attrs):
         """Add inline CSS correctly escaped."""
         self._endtag_close()
-        code = escape_special(esc_style, code)
+        code = escape_special(esc_style, code) if code else ""
         self._pieces.append(f"<style{attributes(attrs)}>{code}</style>")
         return self
+
+    # compat: until version 1.3.0 underscores had to be used
+    _style = style
+    _script = script

--- a/html5tagger/document.py
+++ b/html5tagger/document.py
@@ -32,9 +32,9 @@ def Document(*title, _urls=None, _viewport=False, **html_attrs) -> Builder:
         if args:
             doc.link(href=url, **args)
         elif url.endswith(".js"):
-            doc.script(None, src=url, defer=True)
+            doc.script(src=url, defer=True)
         elif url.endswith(".mjs"):
-            doc.script(None, src=url, type="module")
+            doc.script(src=url, type="module")
         else:
             raise ValueError("Unknown extension in " + fn)
     return doc

--- a/tests/test_html5tagger.py
+++ b/tests/test_html5tagger.py
@@ -59,13 +59,13 @@ def test_html_literal_not_escaped():
 
 def test_script_escaping():
     doc = Document()
-    doc._script("console.log('</script>')")
+    doc.script("console.log('</script>')")
     assert "<script>console.log('<\\/script>')</script>" in str(doc)
 
 
 def test_style_escaping():
     doc = Document()
-    doc._style('h1::after {content: "</Style>"}')
+    doc.style('h1::after {content: "</Style>"}')
     assert '<style>h1::after {content: "<\\/Style>"}</style>' in str(doc)
 
 


### PR DESCRIPTION
We have until now used special methods with leading underscore for these functions. I think we can just replace them with ordinary methods doing the same. This has the implication that these must be followed by parenthesis, simple `doc.script.div...` chaining won't work for these special cases. This is a trade off between zero performance cost and notable performance cost for fully tracking escaping mode within the normal dynamic tag creation, affecting not just scripts and styles. Since script and style normally have attributes or code, this is not expected to break anything. Old `_script` and `_style` are maintained as aliases.
