### PR TITLE
Add doc[bool] conditional no-op toggle for with statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ doc.div["#widget.foo[aria-label=Foo Widget]"](classes=["bar", "baz"], data_user=
 Multiple selectors may be combined in one string and the `[]` and `()` operators may be chained. Overriding values already set is not possible. To append classes use the `classes` keyword argument in the call operator. The values can be single or double quoted or without quotes (no CSS restrictions, anything but `]` allowed). Limited support for backslash escapes is provided as well, e.g. for escaping the backslash itself or the quote character within a quoted value.
 
 
+## Conditional elements
+
+A boolean inside the subscript operator conditionally includes the element
+that follows. When `False`, the tag and any chained call are skipped, but
+the surrounding code still runs normally.
+
+```python
+with doc[use_highlight].mark:
+    doc._("Highlighted when enabled.")
+```
+
+
 ## Preformatted HTML
 
 All content is automatically escaped, unless it provides an `__html__` method that returns a string in HTML format. Similarly, the builder objects of this module expose `__html__` and `_repr_html_` accessors that allow them to be rendered as HTML in Jupyter Notebooks and various other systems that follow this convention.

--- a/html5tagger/builder.py
+++ b/html5tagger/builder.py
@@ -1,6 +1,7 @@
 import re
 
 from .html5 import omit_endtag
+from .nullbuilder import NullBuilder
 from .util import attributes, esc_script, esc_style, escape, escape_attr_value, escape_special, mangle
 
 CSS_SELECTOR = re.compile(
@@ -135,12 +136,11 @@ class Builder:
         return self
 
     def __getitem__(self, item):
-        """Add attributes to the current tag using CSS selector syntax.
+        """Add CSS selector attributes, or return NullBuilder for False."""
+        if isinstance(item, bool):
+            return self if item else NullBuilder
 
-        Supports #id, .class and [attribute=value] (or [attribute] for boolean
-        attributes). Multiple selectors may be combined in a single string.
-        """
-        assert isinstance(item, str), f"CSS selector syntax [] requires a string, got {item!r}."
+        assert isinstance(item, str), f"CSS selector syntax [] requires a string or bool, got {item!r}."
 
         tag = self._pieces[-1]
         assert tag[0] == "<" and tag[-1] == ">" and not tag.startswith("</"), (

--- a/html5tagger/nullbuilder.py
+++ b/html5tagger/nullbuilder.py
@@ -1,6 +1,8 @@
 class _NullBuilder:
     """Silently discards any attempts to add content."""
 
+    __slots__ = ()
+
     def __getattr__(self, name: str):
         return object.__getattribute__(self, name) if name[0] == "_" and name != "_" else self
 

--- a/html5tagger/nullbuilder.py
+++ b/html5tagger/nullbuilder.py
@@ -1,0 +1,23 @@
+class _NullBuilder:
+    """Silently discards any attempts to add content."""
+
+    def __getattr__(self, name: str):
+        return object.__getattribute__(self, name) if name[0] == "_" and name != "_" else self
+
+    def __call__(self, *_content, **_attrs):
+        return self
+
+    def __getitem__(self, _item):
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+    def __repr__(self):
+        return "<NullBuilder>"
+
+
+NullBuilder = _NullBuilder()

--- a/tests/test_html5tagger.py
+++ b/tests/test_html5tagger.py
@@ -249,6 +249,48 @@ def test_css_selector_only_escaped_backslash():
     assert str(snippet) == '<div data-value="\\">Hello</div>'
 
 
+def test_conditional_true_opens_tag():
+    doc = Document()
+    use_highlight = True
+    with doc[use_highlight].mark:
+        doc._("Highlighted")
+    assert str(doc) == "<!DOCTYPE html><mark>Highlighted</mark>"
+
+
+def test_conditional_false_only_skips_tag():
+    doc = Document()
+    use_highlight = False
+    with doc[use_highlight].mark:
+        doc._("Still added")
+    assert str(doc) == "<!DOCTYPE html>Still added"
+
+
+def test_conditional_false_swallows_chained_calls():
+    doc = Document()
+    doc[False].mark("Ignored")
+    doc._("Kept")
+    assert str(doc) == "<!DOCTYPE html>Kept"
+
+
+def test_conditional_getitem_still_rejects_non_bool_non_string():
+    doc = Document()
+    with pytest.raises(AssertionError):
+        doc[123]
+
+
+def test_nullbuilder_getitem_returns_self():
+    nb = Document()[False]
+    assert nb["anything"] is nb
+    assert nb[True] is nb
+    assert nb[False] is nb
+
+
+def test_nullbuilder_private_attribute_raises():
+    nb = Document()[False]
+    with pytest.raises(AttributeError):
+        nb._pieces
+
+
 def test_css_selector_invalid_type_raises():
     with pytest.raises(AssertionError):
         E.div[123]


### PR DESCRIPTION
The Python `with` statement cannot be made conditional due to syntax. This PR adds another overload for the `[]` operator with bool argument to act as such toggle. Using `doc[True]` does nothing and processing after it continues normally. `doc[False]` returns a NullBuilder that does absolutely nothing with anything done to it, in effect discarding further operations on the same statement and `with` statements with it.

```python
with doc[is_enabled].strong:
    doc("always added, sometimes strong")
```
